### PR TITLE
Fix mDNS discovery

### DIFF
--- a/internal/mock/discovery.go
+++ b/internal/mock/discovery.go
@@ -5,13 +5,11 @@
 package mock
 
 import (
-	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	host "github.com/libp2p/go-libp2p-core/host"
-	discovery "github.com/libp2p/go-libp2p-core/discovery"
+	mdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 )
 
 // MockDiscoverer is a mock of Discoverer interface.
@@ -38,16 +36,15 @@ func (m *MockDiscoverer) EXPECT() *MockDiscovererMockRecorder {
 }
 
 // NewMdnsService mocks base method.
-func (m *MockDiscoverer) NewMdnsService(ctx context.Context, peerhost host.Host, interval time.Duration, serviceTag string) (discovery.Service, error) {
+func (m *MockDiscoverer) NewMdnsService(peerhost host.Host, serviceTag string, notifee mdns.Notifee) mdns.Service {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMdnsService", ctx, peerhost, interval, serviceTag)
-	ret0, _ := ret[0].(discovery.Service)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "NewMdnsService", peerhost, serviceTag, notifee)
+	ret0, _ := ret[0].(mdns.Service)
+	return ret0
 }
 
 // NewMdnsService indicates an expected call of NewMdnsService.
-func (mr *MockDiscovererMockRecorder) NewMdnsService(ctx, peerhost, interval, serviceTag interface{}) *gomock.Call {
+func (mr *MockDiscovererMockRecorder) NewMdnsService(peerhost, serviceTag, notifee interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMdnsService", reflect.TypeOf((*MockDiscoverer)(nil).NewMdnsService), ctx, peerhost, interval, serviceTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMdnsService", reflect.TypeOf((*MockDiscoverer)(nil).NewMdnsService), peerhost, serviceTag, notifee)
 }

--- a/internal/wrap/discovery.go
+++ b/internal/wrap/discovery.go
@@ -1,25 +1,16 @@
 package wrap
 
 import (
-	"context"
-
 	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 )
 
 type Discoverer interface {
-	NewMdnsService(ctx context.Context, peerhost host.Host, serviceTag string) (mdns.Service, error)
+	NewMdnsService(peerhost host.Host, serviceTag string, notifee mdns.Notifee) mdns.Service
 }
 
 type Discovery struct{}
 
-func (d Discovery) HandlePeerFound(peer.AddrInfo) {}
-func (d Discovery) NewMdnsService(ctx context.Context, peerhost host.Host, serviceTag string) (mdns.Service, error) {
-	mdns := mdns.NewMdnsService(peerhost, serviceTag, &d)
-	if err := mdns.Start(); err != nil {
-		mdns.Close()
-		return nil, err
-	}
-	return mdns, nil
+func (d Discovery) NewMdnsService(peerhost host.Host, serviceTag string, notifee mdns.Notifee) mdns.Service {
+	return mdns.NewMdnsService(peerhost, serviceTag, notifee)
 }

--- a/pkg/dht/discoverer.go
+++ b/pkg/dht/discoverer.go
@@ -48,7 +48,7 @@ func (d *Discoverer) Discover(chanID int, handler func(info peer.AddrInfo)) erro
 		ctx, cancel := context.WithTimeout(d.ServiceContext(), provideTimeout)
 		for pi := range d.dht.FindProvidersAsync(ctx, cID, 100) {
 			log.Debugln("DHT - Found peer ", pi.ID)
-			//pi.Addrs = onlyPublic(pi.Addrs)
+			pi.Addrs = onlyPublic(pi.Addrs)
 			if isRoutable(pi) {
 				go handler(pi)
 			}

--- a/pkg/mdns/advertiser_test.go
+++ b/pkg/mdns/advertiser_test.go
@@ -4,19 +4,16 @@ import (
 	"context"
 	"sync"
 	"testing"
-	"time"
-
-	"github.com/libp2p/go-libp2p-core/discovery"
-
-	"github.com/dennis-tra/pcp/internal/wrap"
-	"github.com/libp2p/go-libp2p-core/host"
-	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 
 	"github.com/golang/mock/gomock"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dennis-tra/pcp/internal/mock"
+	"github.com/dennis-tra/pcp/internal/wrap"
 )
 
 func setup(t *testing.T) (*gomock.Controller, host.Host, func(t *testing.T)) {
@@ -28,7 +25,6 @@ func setup(t *testing.T) (*gomock.Controller, host.Host, func(t *testing.T)) {
 	net := mocknet.New(context.Background())
 
 	tmpTruncateDuration := TruncateDuration
-	tmpInterval := Interval
 	tmpTimeout := Timeout
 
 	local, err := net.GenPeer()
@@ -38,7 +34,6 @@ func setup(t *testing.T) (*gomock.Controller, host.Host, func(t *testing.T)) {
 		ctrl.Finish()
 
 		TruncateDuration = tmpTruncateDuration
-		Interval = tmpInterval
 		Timeout = tmpTimeout
 
 		wrapdiscovery = wrap.Discovery{}
@@ -59,46 +54,12 @@ func TestAdvertiser_Advertise(t *testing.T) {
 	wg.Add(1)
 
 	d.EXPECT().
-		NewMdnsService(gomock.Any(), a, Interval, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, peerhost host.Host, interval time.Duration, serviceTag string) (discovery.Service, error) {
-			wg.Done()
-			return DummyMDNSService{}, nil
+		NewMdnsService(a, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(peerhost host.Host, serviceTag string, notifee mdns.Notifee) mdns.Service {
+			defer wg.Done()
+			return DummyMDNSService{}
 		}).
 		Times(1)
-
-	go func() {
-		err := a.Advertise(333)
-		assert.NoError(t, err)
-		wg.Done()
-	}()
-	wg.Wait()
-	wg.Add(1)
-
-	a.Shutdown()
-	wg.Wait()
-}
-
-func TestAdvertiser_Advertise_multipleTimes(t *testing.T) {
-	ctrl, local, teardown := setup(t)
-	defer teardown(t)
-
-	Timeout = 20 * time.Millisecond
-
-	d := mock.NewMockDiscoverer(ctrl)
-	wrapdiscovery = d
-
-	a := NewAdvertiser(local)
-
-	var wg sync.WaitGroup
-	wg.Add(5)
-
-	d.EXPECT().
-		NewMdnsService(gomock.Any(), a, Interval, gomock.Any()).
-		DoAndReturn(func(ctx context.Context, peerhost host.Host, interval time.Duration, serviceTag string) (discovery.Service, error) {
-			wg.Done()
-			return DummyMDNSService{}, nil
-		}).
-		Times(5)
 
 	go func() {
 		err := a.Advertise(333)
@@ -117,5 +78,7 @@ type DummyMDNSService struct{}
 func (mdns DummyMDNSService) Close() error {
 	return nil
 }
-func (mdns DummyMDNSService) RegisterNotifee(notifee discovery.Notifee)   {}
-func (mdns DummyMDNSService) UnregisterNotifee(notifee discovery.Notifee) {}
+
+func (mdns DummyMDNSService) Start() error {
+	return nil
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -18,7 +18,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
-
 	"github.com/multiformats/go-varint"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -38,9 +37,9 @@ type State string
 
 const (
 	Idle        State = "idle"
-	Discovering       = "discovering"
-	Advertising       = "advertising"
-	Connected         = "connected"
+	Discovering State = "discovering"
+	Advertising State = "advertising"
+	Connected   State = "connected"
 )
 
 // Node encapsulates the logic for sending and receiving messages.
@@ -102,15 +101,10 @@ func New(c *cli.Context, wrds []string, opts ...libp2p.Option) (*Node, error) {
 
 	opts = append(opts,
 		libp2p.Identity(key),
-		libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"),
-		libp2p.ListenAddrStrings("/ip4/0.0.0.0/udp/0/quic"),
-		libp2p.ListenAddrStrings("/ip6/::/tcp/0"),
-		libp2p.ListenAddrStrings("/ip6/::/udp/0/quic"),
 		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
 			node.DHT, err = kaddht.New(c.Context, h)
 			return node.DHT, err
 		}),
-
 		libp2p.EnableHolePunching(),
 	)
 

--- a/pkg/node/transfer.go
+++ b/pkg/node/transfer.go
@@ -53,7 +53,7 @@ func (t *TransferProtocol) UnregisterTransferHandler() {
 	t.th = nil
 }
 
-// New TransferProtocol initializes a new TransferProtocol object with all
+// NewTransferProtocol initializes a new TransferProtocol object with all
 // fields set to their default values.
 func NewTransferProtocol(node *Node) *TransferProtocol {
 	return &TransferProtocol{node: node, lk: sync.RWMutex{}}


### PR DESCRIPTION
Hi @optman,

I'm filing a PR against your PR to have it all in one place. When you merge it, your PR against the upstream `main` branch will be updated. I fixed the `mDNS` discovery 👍

However, when checking the `libp2p.EnableHolePunching` documentation I noticed:

```
// All existing indefinite long-lived streams on the Relayed connection will have to re-opened on the hole-punched connection by the user.
// Users can make use of the `Connected`/`Disconnected` notifications emitted by the Network for this purpose.
```

This suggests more work and not an out-of-the-box connection upgrade. I'll be able to have a chat with the libp2p devs in a couple of weeks and will ask them about it.